### PR TITLE
Functions for NWIS continuous data

### DIFF
--- a/R/ContinuousDataFunctions.R
+++ b/R/ContinuousDataFunctions.R
@@ -336,7 +336,7 @@ TADA_listNWIS <- function(aoi_sf = "null", states = "null", sites = "null"){
 #' }
 #' 
 TADA_getNWIS <- function(aoi_sf = "null", states = "null", sites = "null", parameter_codes, start_date, end_date){
-  
+  # Confirm only a single argument has been provided
   if (!sum(purrr::map_lgl(list(aoi_sf, states[1], sites[1]), ~ is.null(.x) || (is.character(.x) && .x == "null"))) %in% c(2, 3)) {
     stop(
       paste0(

--- a/R/ContinuousDataFunctions.R
+++ b/R/ContinuousDataFunctions.R
@@ -44,15 +44,14 @@
 #' }
 #'
 TADA_listNWIS <- function(aoi_sf = "null", states = "null", sites = "null"){
-  
-  if (sum(c(aoi_sf, states, sites) == "null") != 2 & sum(c(aoi_sf, states, sites) == "null") != 3) {
+  if (!sum(purrr::map_lgl(list(aoi_sf, states[1], sites[1]), ~ is.null(.x) || (is.character(.x) && .x == "null"))) %in% c(2, 3)) {
     stop(
       paste0(
         "Multiple data-querying arguments (`aoi_sf`, `states`, `sites`) have been provided. ",
         "Please use only one of these query options."
       )
     )
-  } else if (sum(c(aoi_sf, states, sites) == "null") == 3) {
+  } else if (sum(purrr::map_lgl(list(aoi_sf, states[1], sites[1]), ~ is.null(.x) || (is.character(.x) && .x == "null"))) == 3) {
     stop(
       paste0(
         "No data-querying argument (`aoi_sf`, `states`, `sites`) has been provided. ",
@@ -336,14 +335,14 @@ TADA_listNWIS <- function(aoi_sf = "null", states = "null", sites = "null"){
 #' 
 TADA_getNWIS <- function(aoi_sf = "null", states = "null", sites = "null", parameter_codes, start_date, end_date){
   
-  if (sum(c(aoi_sf, states, sites) == "null") != 2 & sum(c(aoi_sf, states, sites) == "null") != 3) {
+  if (!sum(purrr::map_lgl(list(aoi_sf, states[1], sites[1]), ~ is.null(.x) || (is.character(.x) && .x == "null"))) %in% c(2, 3)) {
     stop(
       paste0(
         "Multiple data-querying arguments (`aoi_sf`, `states`, `sites`) have been provided. ",
         "Please use only one of these query options."
       )
     )
-  } else if (sum(c(aoi_sf, states, sites) == "null") == 3) {
+  } else if (sum(purrr::map_lgl(list(aoi_sf, states[1], sites[1]), ~ is.null(.x) || (is.character(.x) && .x == "null"))) == 3) {
     stop(
       paste0(
         "No data-querying argument (`aoi_sf`, `states`, `sites`) has been provided. ",

--- a/R/ContinuousDataFunctions.R
+++ b/R/ContinuousDataFunctions.R
@@ -133,7 +133,7 @@ TADA_listNWIS <- function(aoi_sf = "null", states = "null", sites = "null") {
     validate_aoi_size <- function(aoi_sf) {
       # Get square mile conversion factor for the projection
       # 2.58999e+6 converts square meters to square miles
-      sq_m_to_sq_miles <- 1/2.58999e+6
+      sq_m_to_sq_miles <- 1 / 2.58999e+6
       max_area_sq_miles <- 118078
       
       # Process each feature in the sf object

--- a/R/ContinuousDataFunctions.R
+++ b/R/ContinuousDataFunctions.R
@@ -324,7 +324,7 @@ TADA_listNWIS <- function(aoi_sf = "null", states = "null", sites = "null"){
 #'
 #' @examples
 #' \dontrun{
-#' #' # Example 1: Query by area of interest
+#' # Example 1: Query by area of interest
 #' navajo_sf <- sf::read_sf("inst/extdata/AmericanIndian.shp") %>% dplyr::filter(NAME == "Navajo Nation")
 #' sites_aoi_sf <- TADA_getNWIS(aoi_sf = navajo_sf, parameter_codes = c("00060", "00010"), start_date = "2020-01-01", end_date = "2020-01-31")
 #'

--- a/R/ContinuousDataFunctions.R
+++ b/R/ContinuousDataFunctions.R
@@ -181,7 +181,7 @@ TADA_listNWIS <- function(aoi_sf = "null", states = "null", sites = "null"){
   } else if (any(unlist(sites) != "null")){
     
     # Check and split 'sites' into chunks if necessary
-    # {dataRetrieval} crashes if site list is too big:
+    # {dataRetrieval} is limited by site list length:
     site_chunks <- if (length(sites) > 35000) {
       split(sites, ceiling(seq_along(sites) / 35000))
     } else {

--- a/R/ContinuousDataFunctions.R
+++ b/R/ContinuousDataFunctions.R
@@ -3,7 +3,7 @@
 #' List available USGS daily NWIS data
 #' 
 #' @description
-#' Retrieves available data from USGS National Water Information System (NWIS) based on 
+#' Retrieves available metadata from USGS National Water Information System (NWIS) based on 
 #' different spatial queries: area of interest (AOI), specific sites, or state boundaries.
 #' Returns a spatial {sf} object containing site information and available parameters.
 #' If no data is found, returns an empty sf object with appropriate column structure.

--- a/R/ContinuousDataFunctions.R
+++ b/R/ContinuousDataFunctions.R
@@ -44,6 +44,7 @@
 #' }
 #'
 TADA_listNWIS <- function(aoi_sf = "null", states = "null", sites = "null"){
+# Confirm only a single argument has been provided
   if (!sum(purrr::map_lgl(list(aoi_sf, states[1], sites[1]), ~ is.null(.x) || (is.character(.x) && .x == "null"))) %in% c(2, 3)) {
     stop(
       paste0(

--- a/R/ContinuousDataFunctions.R
+++ b/R/ContinuousDataFunctions.R
@@ -1,0 +1,430 @@
+#' TADA_listNWIS
+#'
+#' List available USGS daily NWIS data
+#' 
+#' @description
+#' Retrieves available data from USGS National Water Information System (NWIS) based on 
+#' different spatial queries: area of interest (AOI), specific sites, or state boundaries.
+#' Returns a spatial {sf} object containing site information and available parameters.
+#' If no data is found, returns an empty sf object with appropriate column structure.
+#'
+#' @param aoi_sf An sf object defining the area of interest.
+#' @param states Character vector of two-letter state codes (e.g., c("CA", "OR")). 
+#' @param sites Character vector of USGS site numbers. 
+#'
+#' @return An sf object containing NWIS site information including:
+#'   \itemize{
+#'     \item site_no: USGS site identification number
+#'     \item site_name: Station name
+#'     \item data_type: Type of data available (e.g., "Daily", "Water Quality")
+#'     \item site_type: Description of the site type
+#'     \item n_obs: Number of observations
+#'     \item begin_date: Start date of data collection
+#'     \item end_date: End date of data collection
+#'     \item parameter: Parameter name and description
+#'     \item code: Parameter code
+#'   }
+#'   Returns an empty sf object with the same structure if no data is found.
+#'
+#' @details Only one of the query arguments (`aoi_sf`, `states`, or `sites`) 
+#' should be provided. The function will stop if none or more than one are provided.
+#' 
+#' @examples
+#' \dontrun{
+#' # Example 1: Query by area of interest
+#' navajo_sf <- sf::read_sf("inst/extdata/AmericanIndian.shp") %>% dplyr::filter(NAME == "Navajo Nation")
+#' sites_aoi_sf <- TADA_listNWIS(aoi_sf = navajo_sf)
+#'
+#' # Example 2: Query by specific site numbers
+#' site_nums <- c("11530500", "11532500")
+#' sites_specific <- TADA_listNWIS(sites = site_nums)
+#'
+#' # Example 3: Query by state
+#' sites_state <- TADA_listNWIS(states = "CA")
+#' }
+#'
+TADA_listNWIS <- function(aoi_sf = "null", states = "null", sites = "null"){
+  
+  if (sum(c(aoi_sf, states, sites) == "null") != 2 & sum(c(aoi_sf, states, sites) == "null") != 3) {
+    stop(
+      paste0(
+        "Multiple data-querying arguments (`aoi_sf`, `states`, `sites`) have been provided. ",
+        "Please use only one of these query options."
+      )
+    )
+  } else if (sum(c(aoi_sf, states, sites) == "null") == 3) {
+    stop(
+      paste0(
+        "No data-querying argument (`aoi_sf`, `states`, `sites`) has been provided. ",
+        "Please select from one of these query options."
+      )
+    )
+  }
+  
+  
+  # Create empty sf object template with correct structure for "no return" data
+  empty_sf <- function() {
+    sf::st_sf(
+      data.frame(
+        site_no = character(),
+        site_name = character(),
+        site_type = character(),
+        site_type_cd = character(),
+        data_type= character(),
+        data_type_cd = character(),
+        parameter = character(),
+        parameter_code = character(),
+        n_obs = character(),
+        begin_date = character(),
+        end_date = character(),
+        geometry = sf::st_sfc(crs = 4269)
+      )
+    )
+  }
+  
+  # Parameter code info grabber:
+  
+  pcodes <- function() {
+    
+    tables <- rvest::read_html('https://help.waterdata.usgs.gov/parameter_cd?group_cd=%') %>%
+      rvest::html_nodes('table') %>%
+      rvest::html_table()
+    
+    pcodes <- tables[[1]] %>%
+      janitor::clean_names() %>%
+      dplyr::mutate(parm_cd = stringr::str_pad(as.character(parameter_code), 5, pad = "0"))
+    
+    return(pcodes)
+    
+  }
+  
+  # Site info grabber:
+  
+  nwis_table <- function() {
+    
+    site_url <- 'https://maps.waterdata.usgs.gov/mapper/help/sitetype.html'
+    
+    table <- rvest::read_html(site_url) %>%
+      rvest::html_nodes('table') %>%
+      rvest::html_table()
+    
+    nwis_table <- rbind(table[[1]], table[[2]], table[[3]], table[[4]], table[[5]]) %>%
+      dplyr::select(site_type_cd = 1,
+                    site_type = 2)
+    
+    return(nwis_table)
+    
+  }
+  
+  # Grab NWIS by an area of interest:
+  if ((unlist(aoi_sf)[1] != "null")){
+    
+    gage_sites <- vector("list", length = nrow(aoi_sf))
+    
+    for (i in 1:nrow(aoi_sf)){
+      
+      bbox <- sf::st_bbox(aoi_sf[i,]) %>%
+        as.vector() %>%
+        round(., digits = 7) %>% 
+        paste(collapse = ",")
+      
+      gage_sites[[i]] <- tryCatch(
+        {
+          suppressMessages(dataRetrieval::whatNWISdata(bBox = bbox, service = "dv"))
+        },
+        error = function(e) {
+          stop("At least one of your user-supplied features in 'aoi_sf' is too large - all features must be less than 118,078 square miles (roughly the area of Nevada). For state queries, please use the argument `state` instead of `aoi_sf`.")
+        }
+      )
+    }
+    
+    gage_sites <- dplyr::bind_rows(gage_sites) 
+    
+    if (nrow(gage_sites) == 0) {
+      message("No daily USGS-NWIS data in selected query.")
+      return(empty_sf())
+    }
+    
+    gage_sites <- gage_sites %>%
+      sf::st_as_sf(coords = c('dec_long_va', 'dec_lat_va'), crs = 4269) # USGS supplies crs 4326 always
+    
+    # Make sure returned USGS object is in the same CRS as what the user-supplied AOI is in:
+    if(sf::st_crs(aoi_sf) != sf::st_crs(gage_sites)){
+      
+      print(paste0("The `aoi_sf` is in CRS = ", sf::st_crs(aoi_sf)$epsg, ". Returning NWIS sites in the same CRS."))
+      gage_sites <- sf::st_transform(gage_sites, sf::st_crs(aoi_sf))
+      
+    }
+    
+    aoi_inventory <- gage_sites %>%
+      .[aoi_sf,] %>%
+      dplyr::left_join(pcodes(), by = "parm_cd") %>%
+      dplyr::left_join(., nwis_table(), by = c("site_tp_cd" = "site_type_cd")) %>%
+      dplyr::mutate(data_type = "Daily") %>%
+      dplyr::select(site_no,
+                    site_name = station_nm,
+                    site_type,
+                    site_type_cd = site_tp_cd,
+                    data_type,
+                    data_type_cd,
+                    parameter = parameter_name_description,
+                    parameter_code = parm_cd,
+                    n_obs = count_nu,
+                    begin_date,
+                    end_date) %>%
+      # remove any dupes if they exist (precautionary - they shouldn't!)
+      dplyr::distinct(., .keep_all = TRUE)
+    
+    return(aoi_inventory)
+    
+    # Grab NWIS by vector of sites:
+  } else if (any(unlist(sites) != "null")){
+    
+    # Check and split 'sites' into chunks if necessary
+    # {dataRetrieval} crashes if site list is too big:
+    site_chunks <- if (length(sites) > 35000) {
+      split(sites, ceiling(seq_along(sites) / 35000))
+    } else {
+      list(sites)
+    }
+    
+    # Map over the chunks to retrieve and process NWIS data
+    site_list_inventory <- purrr::map_dfr(site_chunks, function(chunk) {
+      result <- tryCatch({
+        data <- dataRetrieval::whatNWISdata(siteNumber = chunk, service = "dv")
+        
+        # If no data, return empty data frame
+        if (nrow(data) == 0) {
+          return(empty_sf()) 
+        }
+        
+        data %>%
+          sf::st_as_sf(coords = c('dec_long_va', 'dec_lat_va'), crs = 4269) %>%
+          dplyr::left_join(pcodes(), by = "parm_cd") %>%
+          dplyr::left_join(., nwis_table(), by = c("site_tp_cd" = "site_type_cd")) %>%
+          dplyr::mutate(data_type = "Daily") %>%
+          dplyr::select(site_no,
+                        site_name = station_nm,
+                        site_type,
+                        site_type_cd = site_tp_cd,
+                        data_type,
+                        data_type_cd,
+                        parameter = parameter_name_description,
+                        parameter_code = parm_cd,
+                        n_obs = count_nu,
+                        begin_date,
+                        end_date)
+      }, error = function(e) {
+        message("No daily USGS-NWIS data in selected query.") 
+        return(empty_sf())  # Return an empty df to keep processing
+      })
+      
+      return(result)
+    }) %>%
+      # Remove any duplicates if they exist (precautionary - they shouldn't!)
+      dplyr::distinct(., .keep_all = TRUE)
+    
+    return(site_list_inventory)
+    
+    # Grab NWIS sites by state code: 
+  } else  if (any(unlist(states) != "null")){
+    
+    valid_states <- c("AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE", "FL", "GA",
+                      "HI", "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MD",
+                      "MA", "MI", "MN", "MS", "MO", "MT", "NE", "NV", "NH", "NJ",
+                      "NM", "NY", "NC", "ND", "OH", "OK", "OR", "PA", "RI", "SC",
+                      "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY")
+    
+    if (!any(states %in% valid_states)) {
+      stop("Valid state abbreviation not provided. Please use state abbreviations.")
+    }
+    
+    sites <- vector("list", length = length(states))
+    
+    for(i in 1:length(states)){
+      sites[[i]] <- dataRetrieval::whatNWISsites(stateCd = states[i])
+    }
+    
+    sites <- sites %>% dplyr::bind_rows() %>% dplyr::distinct() %>% .$site_no
+    
+    # Check and split 'sites' into chunks if necessary
+    site_chunks <- if (length(sites) > 35000) {
+      split(sites, ceiling(seq_along(sites) / 35000))
+    } else {
+      list(sites)
+    }
+    
+    # Map over the chunks to retrieve and process NWIS data
+    state_list_inventory <- purrr::map_dfr(site_chunks, function(chunk) {
+      result <- tryCatch({
+        data <- dataRetrieval::whatNWISdata(siteNumber = chunk, service = "dv")
+        
+        # If no data, return empty data frame
+        if (nrow(data) == 0) {
+          return(empty_sf()) 
+        }
+        
+        data %>%
+          sf::st_as_sf(coords = c('dec_long_va', 'dec_lat_va'), crs = 4269) %>%
+          dplyr::left_join(pcodes(), by = "parm_cd") %>%
+          dplyr::left_join(., nwis_table(), by = c("site_tp_cd" = "site_type_cd")) %>%
+          dplyr::mutate(data_type = "Daily") %>%
+          dplyr::select(site_no,
+                        site_name = station_nm,
+                        site_type,
+                        site_type_cd = site_tp_cd,
+                        data_type,
+                        data_type_cd,
+                        parameter = parameter_name_description,
+                        parameter_code = parm_cd,
+                        n_obs = count_nu,
+                        begin_date,
+                        end_date)
+      }, error = function(e) {
+        message("No daily USGS-NWIS data in selected query.") 
+        return(empty_sf())  # Return an empty df to keep processing
+      })
+      
+      return(result)
+    }) %>%
+      # Remove any duplicates if they exist (precautionary - they shouldn't!)
+      dplyr::distinct(., .keep_all = TRUE)
+    
+    
+    return(state_list_inventory)
+    
+  } 
+  
+}
+
+#' Retrieve and tidy daily values from NWIS
+#'
+#' This function interfaces with the USGS National Water Information System (NWIS) to 
+#' retrieve daily values (DV) water quality data using the TADA (Tools for Analysis of 
+#' Data from Agencies) framework. Users can query data based on a spatial area of interest 
+#' (AOI), a vector of state abbreviations, or a vector of specific site numbers, along 
+#' with relevant parameter codes and a date range.
+#'
+#' @param aoi_sf An `sf` object specifying the area of interest.
+#' @param states A character vector of two-letter state abbreviations (e.g., `"CA"`, `"NY"`).
+#' @param sites A character vector of USGS site numbers.
+#' @param parameter_codes A character vector of NWIS parameter codes to filter for (e.g., `"00060"` for discharge). Parameter codes and
+#' names can be found athttps://help.waterdata.usgs.gov/parameter_cd?group_cd=%
+#' @param start_date A character string representing the start date for data retrieval in `"YYYY-MM-DD"` format.
+#' @param end_date A character string representing the end date for data retrieval in `"YYYY-MM-DD"` format.
+#'
+#' @return A tidy `data.frame` containing daily values for each site, date, and parameter, 
+#' including a corresponding status code for each measurement.
+#'
+#' @details Only one of the query arguments (`aoi_sf`, `states`, or `sites`) 
+#' should be provided. The function will stop if none or more than one are provided.
+#' 
+#' @export
+#'
+#' @examples
+#' \dontrun{
+#' #' # Example 1: Query by area of interest
+#' navajo_sf <- sf::read_sf("inst/extdata/AmericanIndian.shp") %>% dplyr::filter(NAME == "Navajo Nation")
+#' sites_aoi_sf <- TADA_getNWIS(aoi_sf = navajo_sf, parameter_codes = c("00060", "00010"), start_date = "2020-01-01", end_date = "2020-01-31")
+#'
+#' # Example 2: Query by specific site numbers
+#' sites_specific <- TADA_getNWIS(sites = c("11530500", "11532500"), parameter_codes = c("00060", "00010"), start_date = "2020-01-01", end_date = "2020-12-31")
+#'
+#' # Example 3: Query by states
+#' nwis_data <- TADA_getNWIS(states = c("RI", "CO"), parameter_codes = c("00060", "00010"), start_date = "2020-01-01", end_date = "2020-01-02")
+#' }
+#' 
+TADA_getNWIS <- function(aoi_sf = "null", states = "null", sites = "null", parameter_codes, start_date, end_date){
+  
+  if (sum(c(aoi_sf, states, sites) == "null") != 2 & sum(c(aoi_sf, states, sites) == "null") != 3) {
+    stop(
+      paste0(
+        "Multiple data-querying arguments (`aoi_sf`, `states`, `sites`) have been provided. ",
+        "Please use only one of these query options."
+      )
+    )
+  } else if (sum(c(aoi_sf, states, sites) == "null") == 3) {
+    stop(
+      paste0(
+        "No data-querying argument (`aoi_sf`, `states`, `sites`) has been provided. ",
+        "Please select from one of these query options."
+      )
+    )
+  }
+  
+  # rename so filter works later
+  end <- end_date
+  
+  # Grab NWIS by an area of interest:
+  if ((unlist(aoi_sf)[1] != "null")){
+    
+    list <- TADA_listNWIS(aoi_sf = aoi_sf) %>%
+      dplyr::filter(parameter_code %in% parameter_codes,
+                    lubridate::ymd(begin_date) <= lubridate::ymd(start_date),
+                    lubridate::ymd(end_date) >= lubridate::ymd(end))
+    
+  } else if ((unlist(states)[1] != "null")){
+    
+    list <- TADA_listNWIS(states = states) %>%
+      dplyr::filter(parameter_code %in% parameter_codes,
+                    lubridate::ymd(begin_date) <= lubridate::ymd(start_date),
+                    lubridate::ymd(end_date) >= lubridate::ymd(end))
+  } else if ((unlist(sites)[1] != "null")){
+    
+    list <- TADA_listNWIS(sites = sites) %>%
+      dplyr::filter(parameter_code %in% parameter_codes,
+                    lubridate::ymd(begin_date) <= lubridate::ymd(start_date),
+                    lubridate::ymd(end_date) >= lubridate::ymd(end))
+  }
+  
+  # Check if list is empty after filtering
+  if (nrow(list) == 0) {
+    stop(paste0("No data available for the specified parameter(s) ", 
+                paste(parameter_codes, collapse = ", "), 
+                " at these sites during the time frame ", 
+                start_date, " to ", end_date, "."))
+  }
+  
+  full_data <- dataRetrieval::readNWISdv(siteNumbers = list$site_no, 
+                                         parameterCd = parameter_codes, 
+                                         startDate = start_date,
+                                         endDate = end) %>%
+    dataRetrieval::renameNWISColumns() %>%
+    data.table::data.table() %>%
+    dplyr::mutate(dplyr::across(dplyr::everything(), as.character))
+  
+  # Check if full_data is empty
+  if (nrow(full_data) == 0) {
+    stop(paste0("Query returned no data for the specified parameter(s) ", 
+                paste(parameter_codes, collapse = ", "), 
+                " at these sites during the time frame ", 
+                start_date, " to ", end_date, "."))
+  }
+  
+  data <- full_data %>%
+    tidyr::pivot_longer(
+      cols = -c(site_no, agency_cd, Date, dplyr::ends_with("_cd")),  # Keep these columns fixed
+      names_to = "NWIS.parameter",
+      values_to = "NWIS.value"
+    ) %>%
+    dplyr::select(NWIS.site_no = site_no, NWIS.date = Date, NWIS.parameter, NWIS.value)
+  
+  status <- full_data %>%
+    tidyr::pivot_longer(
+      cols = c(dplyr::ends_with("_cd"), -agency_cd),  # Keep these columns fixed
+      names_to = "NWIS.parameter",
+      values_to = "NWIS.status"
+    ) %>%
+    dplyr::select(NWIS.status)
+  
+  tidied <- dplyr::bind_cols(data, status) %>%
+    dplyr::filter(!is.na(NWIS.value))
+  
+  # Check if final data is empty after removing NA values
+  if (nrow(tidied) == 0) {
+    stop("All retrieved data contained NA values. No valid data available for the specified parameters and time frame.")
+  }
+  
+  return(tidied)
+  
+}

--- a/R/ContinuousDataFunctions.R
+++ b/R/ContinuousDataFunctions.R
@@ -232,7 +232,8 @@ TADA_listNWIS <- function(aoi_sf = "null", states = "null", sites = "null"){
                       "HI", "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MD",
                       "MA", "MI", "MN", "MS", "MO", "MT", "NE", "NV", "NH", "NJ",
                       "NM", "NY", "NC", "ND", "OH", "OK", "OR", "PA", "RI", "SC",
-                      "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY")
+                      "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY",
+                      "PR")
     
     if (!any(states %in% valid_states)) {
       stop("Valid state abbreviation not provided. Please use state abbreviations.")

--- a/R/ContinuousDataFunctions.R
+++ b/R/ContinuousDataFunctions.R
@@ -308,7 +308,7 @@ TADA_listNWIS <- function(aoi_sf = "null", states = "null", sites = "null"){
 #' @param states A character vector of two-letter state abbreviations (e.g., `"CA"`, `"NY"`).
 #' @param sites A character vector of USGS site numbers.
 #' @param parameter_codes A character vector of NWIS parameter codes to filter for (e.g., `"00060"` for discharge). Parameter codes and
-#' names can be found athttps://help.waterdata.usgs.gov/parameter_cd?group_cd=%
+#' names can be found at https://help.waterdata.usgs.gov/parameter_cd?group_cd=%
 #' @param start_date A character string representing the start date for data retrieval in `"YYYY-MM-DD"` format.
 #' @param end_date A character string representing the end date for data retrieval in `"YYYY-MM-DD"` format.
 #'

--- a/R/ContinuousDataFunctions.R
+++ b/R/ContinuousDataFunctions.R
@@ -5,10 +5,12 @@
 #' @description
 #' Retrieves available metadata from USGS National Water Information System (NWIS) based on 
 #' different spatial queries: area of interest (AOI), specific sites, or state boundaries.
-#' Returns a spatial {sf} object containing site information and available parameters.
+#' Returns a spatial sf object containing site information and available parameters.
 #' If no data is found, returns an empty sf object with appropriate column structure.
 #'
-#' @param aoi_sf An sf object defining the area of interest.
+#' @param aoi_sf An sf object defining the area of interest. All individual sf 
+#' features (or "rows" in the sf data frame) must be under 118,078 square miles 
+#' (roughly the area of Nevada).
 #' @param states Character vector of two-letter state codes (e.g., c("CA", "OR")). 
 #' @param sites Character vector of USGS site numbers. 
 #'
@@ -28,6 +30,7 @@
 #'
 #' @details Only one of the query arguments (`aoi_sf`, `states`, or `sites`) 
 #' should be provided. The function will stop if none or more than one are provided.
+#' Moreover, all sf features must be under 118,078 square miles (roughly the area of Nevada).
 #' 
 #' @examples
 #' \dontrun{
@@ -40,11 +43,11 @@
 #' sites_specific <- TADA_listNWIS(sites = site_nums)
 #'
 #' # Example 3: Query by state
-#' sites_state <- TADA_listNWIS(states = "CA")
+#' sites_state <- TADA_listNWIS(states = c("CT", "RI"))
 #' }
 #'
-TADA_listNWIS <- function(aoi_sf = "null", states = "null", sites = "null"){
-# Confirm only a single argument has been provided
+TADA_listNWIS <- function(aoi_sf = "null", states = "null", sites = "null") {
+  # Confirm only a single argument has been provided
   if (!sum(purrr::map_lgl(list(aoi_sf, states[1], sites[1]), ~ is.null(.x) || (is.character(.x) && .x == "null"))) %in% c(2, 3)) {
     stop(
       paste0(
@@ -70,7 +73,7 @@ TADA_listNWIS <- function(aoi_sf = "null", states = "null", sites = "null"){
         site_name = character(),
         site_type = character(),
         site_type_cd = character(),
-        data_type= character(),
+        data_type = character(),
         data_type_cd = character(),
         parameter = character(),
         parameter_code = character(),
@@ -117,47 +120,91 @@ TADA_listNWIS <- function(aoi_sf = "null", states = "null", sites = "null"){
   }
   
   # Grab NWIS by an area of interest:
-  if ((unlist(aoi_sf)[1] != "null")){
+  if ((unlist(aoi_sf)[1] != "null")) {
+    
+    og_epsg <- sf::st_crs(aoi_sf)$epsg
+    
+    if (sf::st_crs(aoi_sf)$epsg != 4269) {
+      aoi_sf <- aoi_sf %>%
+        sf::st_transform(4269)
+    }
+    
+    # Validate AOI features - stop if any bounding box exceeds 118,078 square miles
+    validate_aoi_size <- function(aoi_sf) {
+      # Get square mile conversion factor for the projection
+      # 2.58999e+6 converts square meters to square miles
+      sq_m_to_sq_miles <- 1/2.58999e+6
+      max_area_sq_miles <- 118078
+      
+      # Process each feature in the sf object
+      aoi_with_area <- aoi_sf %>%
+        dplyr::mutate(
+          bbox_area_sq_miles = purrr::map_dbl(1:dplyr::n(), function(i) {
+            # Get bounding box
+            bbox <- sf::st_bbox(aoi_sf[i, ])
+            
+            # Convert bbox to polygon
+            bbox_polygon <- sf::st_as_sfc(bbox, crs = sf::st_crs(aoi_sf))
+            
+            # Calculate area in square miles
+            area_sq_miles <- sf::st_area(bbox_polygon) * sq_m_to_sq_miles
+            
+            return(as.numeric(area_sq_miles))
+          })
+        )
+      
+      # Check if any area exceeds maximum and stop if too large
+      if (any(aoi_with_area$bbox_area_sq_miles > max_area_sq_miles)) {
+        stop("At least one of your user-supplied features in 'aoi_sf' is too large - all features must be less than 118,078 square miles (roughly the area of Nevada). For state queries, please use the argument `state` instead of `aoi_sf`.")
+      }
+      
+      return(aoi_with_area)
+    }
+    
+    aoi_sf <- validate_aoi_size(aoi_sf)
     
     gage_sites <- vector("list", length = nrow(aoi_sf))
     
-    for (i in 1:nrow(aoi_sf)){
-      
-      bbox <- sf::st_bbox(aoi_sf[i,]) %>%
-        as.vector() %>%
-        round(., digits = 7) %>% 
-        paste(collapse = ",")
-      
-      gage_sites[[i]] <- tryCatch(
-        {
-          suppressMessages(dataRetrieval::whatNWISdata(bBox = bbox, service = "dv"))
-        },
-        error = function(e) {
-          stop("At least one of your user-supplied features in 'aoi_sf' is too large - all features must be less than 118,078 square miles (roughly the area of Nevada). For state queries, please use the argument `state` instead of `aoi_sf`.")
-        }
-      )
-    }
+    suppressMessages({suppressWarnings({
+      for (i in 1:nrow(aoi_sf)) {
+        
+        bbox <- sf::st_bbox(aoi_sf[i, ]) %>%
+          as.vector() %>%
+          round(., digits = 7)
+        
+        gage_sites[[i]] <- tryCatch(
+          {
+            dataRetrieval::whatNWISdata(bBox = c(bbox), service = "dv") %>%
+              dplyr::mutate(dplyr::across(-c(dec_long_va, dec_lat_va), as.character))
+          },
+          error = function(e) {
+            # Get error message as character string
+            err_msg <- as.character(e$message)
+            
+            # Check for HTTP 404 in the error message
+            if (grepl("404", err_msg)) {
+              
+            } else {
+              # For any other error, stop with server error message
+              stop(paste0("Something went wrong:", err_msg, " See https://waterservices.usgs.gov/docs/site-service/site-service-details/#error-codes."))
+              
+            }})
+        
+      }
+    })})
     
     gage_sites <- dplyr::bind_rows(gage_sites) 
     
     if (nrow(gage_sites) == 0) {
-      message("No daily USGS-NWIS data in selected query.")
+      message("No daily USGS-NWIS data in specified query.")
       return(empty_sf())
     }
     
     gage_sites <- gage_sites %>%
-      sf::st_as_sf(coords = c('dec_long_va', 'dec_lat_va'), crs = 4269) # USGS supplies crs 4326 always
-    
-    # Make sure returned USGS object is in the same CRS as what the user-supplied AOI is in:
-    if(sf::st_crs(aoi_sf) != sf::st_crs(gage_sites)){
-      
-      print(paste0("The `aoi_sf` is in CRS = ", sf::st_crs(aoi_sf)$epsg, ". Returning NWIS sites in the same CRS."))
-      gage_sites <- sf::st_transform(gage_sites, sf::st_crs(aoi_sf))
-      
-    }
+      sf::st_as_sf(coords = c('dec_long_va', 'dec_lat_va'), crs = 4269) 
     
     aoi_inventory <- gage_sites %>%
-      .[aoi_sf,] %>%
+      .[aoi_sf, ] %>%
       dplyr::left_join(pcodes(), by = "parm_cd") %>%
       dplyr::left_join(., nwis_table(), by = c("site_tp_cd" = "site_type_cd")) %>%
       dplyr::mutate(data_type = "Daily") %>%
@@ -175,59 +222,31 @@ TADA_listNWIS <- function(aoi_sf = "null", states = "null", sites = "null"){
       # remove any dupes if they exist (precautionary - they shouldn't!)
       dplyr::distinct(., .keep_all = TRUE)
     
+    # Make sure returned USGS object is in the same CRS as what the user-supplied AOI is in:
+    if (as.numeric(og_epsg) != 4269) {
+      message(paste0("The `aoi_sf` is in CRS = ", og_epsg, ". Returning NWIS sites in the same CRS."))
+      aoi_inventory <- sf::st_transform(aoi_inventory, sf::st_crs(og_epsg))
+    }
+    
     return(aoi_inventory)
     
     # Grab NWIS by vector of sites:
-  } else if (any(unlist(sites) != "null")){
+  } else if (any(unlist(sites) != "null")) {
     
     # Check and split 'sites' into chunks if necessary
     # {dataRetrieval} is limited by site list length:
-    site_chunks <- if (length(sites) > 35000) {
-      split(sites, ceiling(seq_along(sites) / 35000))
+    site_chunks <- if (length(sites) > 1000) {
+      message("Your query will return many results and will take some time to process.")
+      split(sites, ceiling(seq_along(sites) / 1000))
     } else {
       list(sites)
     }
     
-    # Map over the chunks to retrieve and process NWIS data
-    site_list_inventory <- purrr::map_dfr(site_chunks, function(chunk) {
-      result <- tryCatch({
-        data <- dataRetrieval::whatNWISdata(siteNumber = chunk, service = "dv")
-        
-        # If no data, return empty data frame
-        if (nrow(data) == 0) {
-          return(empty_sf()) 
-        }
-        
-        data %>%
-          sf::st_as_sf(coords = c('dec_long_va', 'dec_lat_va'), crs = 4269) %>%
-          dplyr::left_join(pcodes(), by = "parm_cd") %>%
-          dplyr::left_join(., nwis_table(), by = c("site_tp_cd" = "site_type_cd")) %>%
-          dplyr::mutate(data_type = "Daily") %>%
-          dplyr::select(site_no,
-                        site_name = station_nm,
-                        site_type,
-                        site_type_cd = site_tp_cd,
-                        data_type,
-                        data_type_cd,
-                        parameter = parameter_name_description,
-                        parameter_code = parm_cd,
-                        n_obs = count_nu,
-                        begin_date,
-                        end_date)
-      }, error = function(e) {
-        message("No daily USGS-NWIS data in selected query.") 
-        return(empty_sf())  # Return an empty df to keep processing
-      })
-      
-      return(result)
-    }) %>%
-      # Remove any duplicates if they exist (precautionary - they shouldn't!)
-      dplyr::distinct(., .keep_all = TRUE)
-    
-    return(site_list_inventory)
-    
     # Grab NWIS sites by state code: 
-  } else  if (any(unlist(states) != "null")){
+  } else if (any(unlist(states) != "null")) {
+    
+    # ensure proper capitalization
+    states <- toupper(states)
     
     valid_states <- c("AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE", "FL", "GA",
                       "HI", "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MD",
@@ -242,61 +261,98 @@ TADA_listNWIS <- function(aoi_sf = "null", states = "null", sites = "null"){
     
     sites <- vector("list", length = length(states))
     
-    for(i in 1:length(states)){
-      sites[[i]] <- dataRetrieval::whatNWISsites(stateCd = states[i])
-    }
+    suppressWarnings({suppressMessages({
+      for (i in 1:length(states)) {
+        tryCatch({
+          sites[[i]] <- dataRetrieval::whatNWISsites(stateCd = states[i]) %>%
+            dplyr::mutate(dplyr::across(-c(dec_long_va, dec_lat_va), as.character))
+        }, error = function(e) {
+          # Get error message as character string
+          err_msg <- as.character(e$message)
+          
+          # Check for HTTP 404 in the error message
+          if (grepl("404", err_msg)) {
+            
+          } else {
+            # For any other error, stop with server error message
+            stop(paste0("Something went wrong:", err_msg, " See https://waterservices.usgs.gov/docs/site-service/site-service-details/#error-codes."))
+          }})
+      }
+    })})
     
     sites <- sites %>% dplyr::bind_rows() %>% dplyr::distinct() %>% .$site_no
     
     # Check and split 'sites' into chunks if necessary
-    site_chunks <- if (length(sites) > 35000) {
-      split(sites, ceiling(seq_along(sites) / 35000))
+    site_chunks <- if (length(sites) > 1000) {
+      message("Your query will return many results and will take some time to process.")
+      split(sites, ceiling(seq_along(sites) / 1000))
     } else {
       list(sites)
     }
     
-    # Map over the chunks to retrieve and process NWIS data
-    state_list_inventory <- purrr::map_dfr(site_chunks, function(chunk) {
-      result <- tryCatch({
-        data <- dataRetrieval::whatNWISdata(siteNumber = chunk, service = "dv")
-        
-        # If no data, return empty data frame
-        if (nrow(data) == 0) {
-          return(empty_sf()) 
-        }
-        
-        data %>%
-          sf::st_as_sf(coords = c('dec_long_va', 'dec_lat_va'), crs = 4269) %>%
-          dplyr::left_join(pcodes(), by = "parm_cd") %>%
-          dplyr::left_join(., nwis_table(), by = c("site_tp_cd" = "site_type_cd")) %>%
-          dplyr::mutate(data_type = "Daily") %>%
-          dplyr::select(site_no,
-                        site_name = station_nm,
-                        site_type,
-                        site_type_cd = site_tp_cd,
-                        data_type,
-                        data_type_cd,
-                        parameter = parameter_name_description,
-                        parameter_code = parm_cd,
-                        n_obs = count_nu,
-                        begin_date,
-                        end_date)
-      }, error = function(e) {
-        message("No daily USGS-NWIS data in selected query.") 
-        return(empty_sf())  # Return an empty df to keep processing
-      })
-      
-      return(result)
-    }) %>%
-      # Remove any duplicates if they exist (precautionary - they shouldn't!)
-      dplyr::distinct(., .keep_all = TRUE)
-    
-    
-    return(state_list_inventory)
-    
-  } 
+  }
   
-}
+  # Map over the chunks to retrieve and process NWIS data
+  
+  inventory <- vector("list", length = length(site_chunks))
+  
+  for (i in 1:length(site_chunks)) {
+    
+    suppressWarnings({suppressMessages({
+      inventory[[i]] <- tryCatch({
+        data <- dataRetrieval::whatNWISdata(siteNumber = site_chunks[[i]], service = "dv") %>%
+          dplyr::mutate(dplyr::across(-c(dec_long_va, dec_lat_va), as.character))
+      }, error = function(e) {
+        # Get error message as character string
+        err_msg <- as.character(e$message)
+        
+        # Check for HTTP 404 in the error message
+        if (grepl("404", err_msg)) {
+          empty_sf()
+        } else {
+          # For any other error, stop with server error message
+          stop(paste0("Something went wrong:", err_msg, " See https://waterservices.usgs.gov/docs/site-service/site-service-details/#error-codes."))
+        }})
+      
+    })})
+    
+  }
+  
+  inventory <- dplyr::bind_rows(inventory)
+  
+  # If no data, return empty data frame
+  if (nrow(inventory) == 0) {
+    return(empty_sf()) 
+  }
+  
+  inventory <- inventory %>%
+    sf::st_as_sf(coords = c('dec_long_va', 'dec_lat_va'), crs = 4269) %>%
+    dplyr::left_join(pcodes(), by = "parm_cd") %>%
+    dplyr::left_join(., nwis_table(), by = c("site_tp_cd" = "site_type_cd")) %>%
+    dplyr::mutate(data_type = "Daily") %>%
+    dplyr::select(site_no,
+                  site_name = station_nm,
+                  site_type,
+                  site_type_cd = site_tp_cd,
+                  data_type,
+                  data_type_cd,
+                  parameter = parameter_name_description,
+                  parameter_code = parm_cd,
+                  n_obs = count_nu,
+                  begin_date,
+                  end_date) %>%
+    # Remove any duplicates if they exist (precautionary - they shouldn't!)
+    dplyr::distinct(., .keep_all = TRUE)
+  
+  
+  # If no data, return empty data frame
+  if (nrow(inventory) == 0) {
+    message("No daily USGS-NWIS data in specified query.")
+    return(empty_sf()) 
+  }
+  return(inventory)
+} 
+
 
 #' Retrieve and tidy daily values from NWIS
 #'
@@ -306,7 +362,9 @@ TADA_listNWIS <- function(aoi_sf = "null", states = "null", sites = "null"){
 #' (AOI), a vector of state abbreviations, or a vector of specific site numbers, along 
 #' with relevant parameter codes and a date range.
 #'
-#' @param aoi_sf An `sf` object specifying the area of interest.
+#' @param aoi_sf An sf object defining the area of interest. All individual sf 
+#' features (or "rows" in the sf data frame) must be under 118,078 square miles 
+#' (roughly the area of Nevada).
 #' @param states A character vector of two-letter state abbreviations (e.g., `"CA"`, `"NY"`).
 #' @param sites A character vector of USGS site numbers.
 #' @param parameter_codes A character vector of NWIS parameter codes to filter for (e.g., `"00060"` for discharge). Parameter codes and
@@ -319,14 +377,15 @@ TADA_listNWIS <- function(aoi_sf = "null", states = "null", sites = "null"){
 #'
 #' @details Only one of the query arguments (`aoi_sf`, `states`, or `sites`) 
 #' should be provided. The function will stop if none or more than one are provided.
+#' Moreover, all sf features must be under 118,078 square miles (roughly the area of Nevada).
 #' 
 #' @export
 #'
 #' @examples
 #' \dontrun{
 #' # Example 1: Query by area of interest
-#' navajo_sf <- sf::read_sf("inst/extdata/AmericanIndian.shp") %>% dplyr::filter(NAME == "Navajo Nation")
-#' sites_aoi_sf <- TADA_getNWIS(aoi_sf = navajo_sf, parameter_codes = c("00060", "00010"), start_date = "2020-01-01", end_date = "2020-01-31")
+#' locs_sf <- sf::read_sf("inst/extdata/AmericanIndian.shp") %>% dplyr::filter(NAME %in% c("Spokane", "Navajo Nation"))
+#' sites_aoi_sf <- TADA_getNWIS(aoi_sf = locs_sf, parameter_codes = c("00060", "00010"), start_date = "2020-01-01", end_date = "2020-01-31")
 #'
 #' # Example 2: Query by specific site numbers
 #' sites_specific <- TADA_getNWIS(sites = c("11530500", "11532500"), parameter_codes = c("00060", "00010"), start_date = "2020-01-01", end_date = "2020-12-31")
@@ -335,7 +394,7 @@ TADA_listNWIS <- function(aoi_sf = "null", states = "null", sites = "null"){
 #' nwis_data <- TADA_getNWIS(states = c("RI", "CO"), parameter_codes = c("00060", "00010"), start_date = "2020-01-01", end_date = "2020-01-02")
 #' }
 #' 
-TADA_getNWIS <- function(aoi_sf = "null", states = "null", sites = "null", parameter_codes, start_date, end_date){
+TADA_getNWIS <- function(aoi_sf = "null", states = "null", sites = "null", parameter_codes, start_date, end_date) {
   # Confirm only a single argument has been provided
   if (!sum(purrr::map_lgl(list(aoi_sf, states[1], sites[1]), ~ is.null(.x) || (is.character(.x) && .x == "null"))) %in% c(2, 3)) {
     stop(
@@ -357,25 +416,119 @@ TADA_getNWIS <- function(aoi_sf = "null", states = "null", sites = "null", param
   end <- end_date
   
   # Grab NWIS by an area of interest:
-  if ((unlist(aoi_sf)[1] != "null")){
+  # For large areas, this is quite slow.
+  
+  if ((unlist(aoi_sf)[1] != "null")) {
+    # Validate AOI features - stop if any bounding box exceeds 118,078 square miles
+    validate_aoi_size <- function(aoi_sf) {
+      # Get square mile conversion factor for the projection
+      # 2.58999e+6 converts square meters to square miles
+      sq_m_to_sq_miles <- 1/2.58999e+6
+      max_area_sq_miles <- 118078
+      
+      # Process each feature in the sf object
+      aoi_with_area <- aoi_sf %>%
+        dplyr::mutate(
+          bbox_area_sq_miles = purrr::map_dbl(1:dplyr::n(), function(i) {
+            # Get bounding box
+            bbox <- sf::st_bbox(aoi_sf[i, ])
+            
+            # Convert bbox to polygon
+            bbox_polygon <- sf::st_as_sfc(bbox, crs = sf::st_crs(aoi_sf))
+            
+            # Calculate area in square miles
+            area_sq_miles <- sf::st_area(bbox_polygon) * sq_m_to_sq_miles
+            
+            return(as.numeric(area_sq_miles))
+          })
+        )
+      
+      # Check if any area exceeds maximum and stop if too large
+      if (any(aoi_with_area$bbox_area_sq_miles > max_area_sq_miles)) {
+        stop("At least one of your user-supplied features in 'aoi_sf' is too large - all features must be less than 118,078 square miles (roughly the area of Nevada). For state queries, please use the argument `state` instead of `aoi_sf`.")
+      }
+      
+      return(aoi_with_area)
+    }
     
-    list <- TADA_listNWIS(aoi_sf = aoi_sf) %>%
-      dplyr::filter(parameter_code %in% parameter_codes,
-                    lubridate::ymd(begin_date) <= lubridate::ymd(start_date),
-                    lubridate::ymd(end_date) >= lubridate::ymd(end))
+    aoi_sf <- validate_aoi_size(aoi_sf)
     
-  } else if ((unlist(states)[1] != "null")){
+    sites <- vector("list", length = nrow(aoi_sf))
     
-    list <- TADA_listNWIS(states = states) %>%
-      dplyr::filter(parameter_code %in% parameter_codes,
-                    lubridate::ymd(begin_date) <= lubridate::ymd(start_date),
-                    lubridate::ymd(end_date) >= lubridate::ymd(end))
-  } else if ((unlist(sites)[1] != "null")){
+    suppressMessages({suppressWarnings({
+      for (i in 1:nrow(aoi_sf)) {
+        
+        bbox <- sf::st_bbox(aoi_sf[i, ]) %>%
+          as.vector() %>%
+          round(., digits = 7)
+        
+        sites[[i]] <- tryCatch(
+          {
+            dataRetrieval::whatNWISdata(bBox = c(bbox), service = "dv", startDate = start_date, endDate = end_date, parameterCd = parameter_codes) %>%
+              dplyr::mutate(dplyr::across(-c(dec_long_va, dec_lat_va), as.character))
+          },
+          error = function(e) {
+            # Get error message as character string
+            err_msg <- as.character(e$message)
+            
+            # Check for HTTP 404 in the error message
+            if (grepl("404", err_msg)) {
+              
+            } else {
+              # For any other error, stop with server error message
+              stop(paste0("Something went wrong:", err_msg, " See https://waterservices.usgs.gov/docs/site-service/site-service-details/#error-codes."))
+            }})
+        
+      }
+    })})
     
-    list <- TADA_listNWIS(sites = sites) %>%
-      dplyr::filter(parameter_code %in% parameter_codes,
-                    lubridate::ymd(begin_date) <= lubridate::ymd(start_date),
-                    lubridate::ymd(end_date) >= lubridate::ymd(end))
+    list <- dplyr::bind_rows(sites) 
+    
+    # Grab NWIS by states:
+  } else if ((unlist(states)[1] != "null")) {
+    
+    # ensure proper capitalization
+    states <- toupper(states)
+    
+    valid_states <- c("AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE", "FL", "GA",
+                      "HI", "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MD",
+                      "MA", "MI", "MN", "MS", "MO", "MT", "NE", "NV", "NH", "NJ",
+                      "NM", "NY", "NC", "ND", "OH", "OK", "OR", "PA", "RI", "SC",
+                      "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY",
+                      "PR")
+    
+    if (!any(states %in% valid_states)) {
+      stop("Valid state abbreviation not provided. Please use state abbreviations.")
+    }
+    
+    sites <- vector("list", length = length(states))
+    
+    suppressWarnings({suppressMessages({
+      for (i in 1:length(states)) {
+        
+        tryCatch({
+          sites[[i]] <- dataRetrieval::whatNWISdata(stateCd = states[i], service = "dv", startDate = start_date, endDate = end_date, parameterCd = parameter_codes) %>%
+            dplyr::mutate(dplyr::across(-c(dec_long_va, dec_lat_va), as.character))
+        }, error = function(e) {
+          # Get error message as character string
+          err_msg <- as.character(e$message)
+          
+          # Check for HTTP 404 in the error message
+          if (grepl("404", err_msg)) {
+            
+          } else {
+            # For any other error, stop with server error message
+            stop(paste0("Something went wrong:", err_msg, " See https://waterservices.usgs.gov/docs/site-service/site-service-details/#error-codes."))
+          }})
+      }
+    })})
+    
+    list <- sites %>% dplyr::bind_rows() %>% dplyr::distinct() 
+    
+  } else if ((unlist(sites)[1] != "null")) {
+    
+    list <- tibble::tibble(site_no = sites)
+    
   }
   
   # Check if list is empty after filtering
@@ -386,13 +539,59 @@ TADA_getNWIS <- function(aoi_sf = "null", states = "null", sites = "null", param
                 start_date, " to ", end_date, "."))
   }
   
-  full_data <- dataRetrieval::readNWISdv(siteNumbers = list$site_no, 
-                                         parameterCd = parameter_codes, 
-                                         startDate = start_date,
-                                         endDate = end) %>%
-    dataRetrieval::renameNWISColumns() %>%
-    data.table::data.table() %>%
-    dplyr::mutate(dplyr::across(dplyr::everything(), as.character))
+  # Check if we need to split the sites into chunks
+  site_chunks <- if (length(list$site_no) > 1000) {
+    message("Your query contains many sites and will take some time to process.")
+    split(list$site_no, ceiling(seq_along(list$site_no) / 1000))
+  } else {
+    list(list$site_no)
+  }
+  
+  # Map over the chunks to retrieve and process NWIS data
+  full_data <- {
+    
+    purrr::map_dfr(site_chunks, function(chunk) {
+      
+      # Process chunk with error handling
+      result <- tryCatch({
+        suppressMessages({suppressWarnings({
+          data <- dataRetrieval::readNWISdv(siteNumbers = chunk, 
+                                            parameterCd = parameter_codes, 
+                                            startDate = start_date,
+                                            endDate = end_date) 
+          
+          if (nrow(data) > 0) {
+            data <- data %>%
+              dataRetrieval::renameNWISColumns() %>%
+              data.table::data.table() %>%
+              dplyr::mutate(dplyr::across(dplyr::everything(), as.character))
+          }
+          
+          return(data)
+        })})
+      }, error = function(e) {
+        # Get error message as character string
+        err_msg <- as.character(e$message)
+        
+        # Check for HTTP 404 in the error message
+        if (grepl("404", err_msg)) {
+          # Return empty data frame with appropriate structure
+          return(data.frame())
+        } else {
+          # For any other error, stop with server error message
+          stop(paste0("Something went wrong: ", err_msg, 
+                      " See https://waterservices.usgs.gov/docs/site-service/site-service-details/#error-codes."))
+        }
+      })
+      
+      return(result)
+    })
+  }
+  
+  # If no data found across all chunks, inform user
+  if (nrow(full_data) == 0) {
+    message("No daily USGS-NWIS data found for the specified parameters and date range.")
+  }
   
   # Check if full_data is empty
   if (nrow(full_data) == 0) {

--- a/tests/testthat/test-ContinuousDataFunctions.R
+++ b/tests/testthat/test-ContinuousDataFunctions.R
@@ -1,0 +1,128 @@
+# Tests for TADA_listNWIS
+testthat::test_that("TADA_listNWIS returns correct structure when querying by sites", {
+  # Test with known site numbers
+  site_nums <- c("11530500", "11532500")
+  sites_result <- TADA_listNWIS(sites = site_nums)
+  
+  # Check basic structure and content
+  testthat::expect_s3_class(sites_result, "sf")
+  testthat::expect_true("site_no" %in% colnames(sites_result))
+  testthat::expect_true("parameter" %in% colnames(sites_result))
+  testthat::expect_true(all(sites_result$site_no %in% site_nums))
+})
+
+testthat::test_that("TADA_listNWIS returns empty sf with correct structure when no data found", {
+  # Test with non-existent site
+  nonexistent_site <- "99999999"
+  result <- TADA_listNWIS(sites = nonexistent_site)
+  
+  # Check structure of empty return
+  testthat::expect_s3_class(result, "sf")
+  testthat::expect_equal(nrow(result), 0)
+  expected_cols <- c("site_no", "site_name", "site_type", "site_type_cd", 
+                     "data_type", "data_type_cd", "parameter", "parameter_code", 
+                     "n_obs", "begin_date", "end_date", "geometry")
+  testthat::expect_true(all(expected_cols %in% colnames(result)))
+})
+
+testthat::test_that("TADA_listNWIS validates input parameters correctly", {
+  # Test with multiple query types
+  testthat::expect_error(
+    TADA_listNWIS(sites = c("11530500"), states = "CA"),
+    "Multiple data-querying arguments"
+  )
+  
+  # Test with no query types
+  testthat::expect_error(
+    TADA_listNWIS(),
+    "No data-querying argument"
+  )
+  
+  # Test invalid state code
+  testthat::expect_error(
+    TADA_listNWIS(states = "ZZ"),
+    "Valid state abbreviation not provided"
+  )
+})
+
+# Tests for TADA_getNWIS
+testthat::test_that("TADA_getNWIS returns correct structure with site query", {
+  # Test with known site that has discharge data
+  site_num <- "11530500"
+  start_date <- "2020-01-01"
+  end_date <- "2020-01-05"
+  
+  result <- TADA_getNWIS(
+    sites = site_num, 
+    parameter_codes = "00060", 
+    start_date = start_date, 
+    end_date = end_date
+  )
+  
+  # Check structure and content
+  testthat::expect_s3_class(result, "data.frame")
+  testthat::expect_true(all(c("NWIS.site_no", "NWIS.date", "NWIS.parameter", "NWIS.value", "NWIS.status") %in% colnames(result)))
+  testthat::expect_true(all(result$NWIS.site_no == site_num))
+  testthat::expect_true(all(as.Date(result$NWIS.date) >= as.Date(start_date)))
+  testthat::expect_true(all(as.Date(result$NWIS.date) <= as.Date(end_date)))
+})
+
+testthat::test_that("TADA_getNWIS handles errors when no data is available", {
+  # Test with valid site but non-existent parameter code
+  site_num <- "11530500"
+  invalid_param <- "99999"  # Non-existent parameter
+  
+  testthat::expect_error(
+    TADA_getNWIS(
+      sites = site_num, 
+      parameter_codes = invalid_param, 
+      start_date = "2020-01-01", 
+      end_date = "2020-01-05"
+    ),
+    "No data available for the specified parameter"
+  )
+  
+  # Test with valid site but date range before data collection
+  testthat::expect_error(
+    TADA_getNWIS(
+      sites = site_num, 
+      parameter_codes = "00060", 
+      start_date = "1800-01-01", 
+      end_date = "1800-01-05"
+    ),
+    "No data available"
+  )
+})
+
+testthat::test_that("TADA_getNWIS validates input parameters correctly", {
+  # Test with multiple query types
+  testthat::expect_error(
+    TADA_getNWIS(
+      sites = "11530500", 
+      states = "CA", 
+      parameter_codes = "00060", 
+      start_date = "2020-01-01", 
+      end_date = "2020-01-05"
+    ),
+    "Multiple data-querying arguments"
+  )
+  
+  # Test with no query types
+  testthat::expect_error(
+    TADA_getNWIS(
+      parameter_codes = "00060", 
+      start_date = "2020-01-01", 
+      end_date = "2020-01-05"
+    ),
+    "No data-querying argument"
+  )
+  
+  # Test with missing required parameters
+  testthat::expect_error(
+    TADA_getNWIS(
+      sites = "11530500",
+      start_date = "2020-01-01", 
+      end_date = "2020-01-05"
+    )
+  )
+})

--- a/tests/testthat/test-ContinuousDataFunctions.R
+++ b/tests/testthat/test-ContinuousDataFunctions.R
@@ -45,6 +45,50 @@ testthat::test_that("TADA_listNWIS validates input parameters correctly", {
   )
 })
 
+testthat::test_that("TADA_listNWIS errors when aoi_sf is too large", {
+
+  # Test big shapefiles (should error if larger than 118,078 square miles)
+  
+  # Create an artificially large polygon (covering most of the US)
+  large_bbox <- c(
+    xmin = -125, # West coast
+    ymin = 24,   # Southern border
+    xmax = -66,  # East coast
+    ymax = 49    # Northern border
+  )
+  
+  # Convert to bbox object, then to sfc
+  large_poly <- sf::st_as_sfc(sf::st_bbox(large_bbox, crs = 4269))
+  large_sf <- sf::st_sf(geometry = large_poly)
+  
+  # Test with artificial large AOI
+  testthat::expect_error(
+    TADA_listNWIS(aoi_sf = large_sf),
+    "At least one of your user-supplied features in 'aoi_sf' is too large"
+  )
+  
+  # Create a multi-feature sf object with one small and one large polygon
+  small_bbox <- c(
+    xmin = -77.1,
+    ymin = 38.8,
+    xmax = -76.9,
+    ymax = 38.9
+  )
+  
+  small_poly <- sf::st_as_sfc(sf::st_bbox(small_bbox, crs = 4269))
+  
+  combined_sf <- sf::st_sf(
+    name = c("small", "large"),
+    geometry = c(small_poly, large_poly)
+  )
+  
+  # Test with combined small+large features
+  testthat::expect_error(
+    TADA_listNWIS(aoi_sf = combined_sf),
+    "At least one of your user-supplied features in 'aoi_sf' is too large"
+  )
+})
+
 # Tests for TADA_getNWIS
 testthat::test_that("TADA_getNWIS returns correct structure with site query", {
   # Test with known site that has discharge data
@@ -65,33 +109,6 @@ testthat::test_that("TADA_getNWIS returns correct structure with site query", {
   testthat::expect_true(all(result$NWIS.site_no == site_num))
   testthat::expect_true(all(as.Date(result$NWIS.date) >= as.Date(start_date)))
   testthat::expect_true(all(as.Date(result$NWIS.date) <= as.Date(end_date)))
-})
-
-testthat::test_that("TADA_getNWIS handles errors when no data is available", {
-  # Test with valid site but non-existent parameter code
-  site_num <- "11530500"
-  invalid_param <- "99999"  # Non-existent parameter
-  
-  testthat::expect_error(
-    TADA_getNWIS(
-      sites = site_num, 
-      parameter_codes = invalid_param, 
-      start_date = "2020-01-01", 
-      end_date = "2020-01-05"
-    ),
-    "No data available for the specified parameter"
-  )
-  
-  # Test with valid site but date range before data collection
-  testthat::expect_error(
-    TADA_getNWIS(
-      sites = site_num, 
-      parameter_codes = "00060", 
-      start_date = "1800-01-01", 
-      end_date = "1800-01-05"
-    ),
-    "No data available"
-  )
 })
 
 testthat::test_that("TADA_getNWIS validates input parameters correctly", {
@@ -126,3 +143,4 @@ testthat::test_that("TADA_getNWIS validates input parameters correctly", {
     )
   )
 })
+

--- a/vignettes/TADAModule2.Rmd
+++ b/vignettes/TADAModule2.Rmd
@@ -362,24 +362,25 @@ this function in use and additional information.
 
 # USGS National Water Information System (NWIS) Functions
 
-TADA also provides functions to access continuous daily USGS National Water 
-Information System (NWIS) data. These functions allow you to query and retrieve
-continuous daily-value data from USGS water monitoring locations.
+TADA also provides functions to access continuous daily USGS National
+Water Information System (NWIS) data. These functions allow you to query
+and retrieve continuous daily-value data from USGS water monitoring
+locations.
 
 ### `TADA_listNWIS()`
 
-This function retrieves all available daily data from USGS National Water
-Information System (NWIS) based on different queries: an area of interest
-(i.e., an sf object), states, or specific sites.
+This function retrieves all available daily data from USGS National
+Water Information System (NWIS) based on different queries: an area of
+interest (i.e., an sf object), states, or specific sites.
 
-The function returns a spatial sf object containing site information
-and available parameters. If no data is found, it returns an empty sf
-object with the appropriate column structure.
+The function returns a spatial sf object containing site information and
+available parameters. If no data is found, it returns an empty sf object
+with the appropriate column structure.
 
 #### Using `TADA_listNWIS()`
 
-Let's retrieve information about available NWIS data by a state, then visualize
-that information:
+Let's retrieve information about available NWIS data by a state, then
+visualize that information:
 
 ```{r}
 # Example: Query by state 
@@ -441,25 +442,29 @@ cherokee_nwis <- TADA_listNWIS(aoi_sf = cherokee_sf)
 
 This function retrieves and tidy-formats daily values from NWIS. It
 interfaces with the USGS National Water Information System to retrieve
-daily value (DV) water data. Like `TADA_listNWIS()`, users can
-query data based on an area of interest (i.e., an sf object), states,
-or specific sites.
+daily value (DV) water data. Like `TADA_listNWIS()`, users can query
+data based on an area of interest (i.e., an sf object), states, or
+specific sites.
 
-Additionally, users must specify the parameter codes they want to download
-and a date range. A list of all available parameters can be found at: 
-https://help.waterdata.usgs.gov/parameter_cd?group_cd=%
-
+Additionally, users must specify the parameter codes they want to
+download and a date range. A list of all available parameters can be
+found at:
+[https://help.waterdata.usgs.gov/parameter_cd?group_cd=%](https://help.waterdata.usgs.gov/parameter_cd?group_cd=%){.uri}
 
 #### Using `TADA_getNWIS()`
 
-Let's retrieve water temperature data (parameter code 00010) being collected in the sf
-object above for January 2022:
+With TADA_getNWIS(), users can retrieve time series data available from
+USGS sites by specifying the desired locations (using site identifiers,
+spatial feature (sf) objects, or states - similar to `TADA_listNWIS()`),
+parameter codes, and a time period. Let's retrieve water temperature
+data (parameter code 00010) being collected in the sf object above for
+January 2022:
 
 ```{r}
 # Example: Retrieve water temperature data within a specified area of interest:
 temperature_data <- TADA_getNWIS(
-  aoi_sf = cherokee_sf,
-  parameter_codes = "00010",  # Discharge in cubic feet per second
+  aoi_sf = cherokee_sf, #could also use argumens `states` or `sites`
+  parameter_codes = "00010",  # water temperature in Celsius
   start_date = "2022-01-01", 
   end_date = "2022-01-31"
 )

--- a/vignettes/TADAModule2.Rmd
+++ b/vignettes/TADAModule2.Rmd
@@ -359,3 +359,84 @@ TADA_ViewATTAINS(.data = TADA_with_ATTAINS_filled)
 
 Enter `?TADA_ViewATTAINS` into the console to review another example of
 this function in use and additional information.
+
+# USGS National Water Information System (NWIS) Functions
+
+TADA also provides functions to access continuous daily USGS National Water 
+Information System (NWIS) data. These functions allow you to query and retrieve
+continuous daily-value data from USGS water monitoring locations.
+
+### `TADA_listNWIS()`
+
+This function retrieves available data from USGS National Water
+Information System (NWIS) based on different queries: an area of interest
+(i.e., an {sf} object), states, or specific sites.
+
+The function returns a spatial {sf} object containing site information
+and available parameters. If no data is found, it returns an empty sf
+object with the appropriate column structure.
+
+#### Using `TADA_listNWIS()`
+
+Let's retrieve information about available NWIS data for specific USGS
+monitoring sites:
+
+```{r}
+# Example: Query by specific site numbers
+site_nums <- c("11530500", "11532500")  # Two sites in Northern California
+sites_info <- TADA_listNWIS(sites = site_nums)
+View(sites_info)
+```
+
+We can also query NWIS sites by state:
+
+```{r, eval=FALSE}
+# Example: Query by state (showing code but not evaluating to limit runtime)
+ri_sites <- TADA_listNWIS(states = "RI")
+```
+
+### `TADA_getNWIS()`
+
+This function retrieves and tidy-formats daily values from NWIS. It
+interfaces with the USGS National Water Information System to retrieve
+daily values (DV) water data. Like `TADA_listNWIS()`, users can
+query data based on an area of interest (i.e., an {sf} object), states,
+or specific sites.
+
+
+Additionally, users specify relevant parameter codes and a date range.
+
+#### Using `TADA_getNWIS()`
+
+Let's retrieve discharge data (parameter code 00060) for the sites we
+queried above:
+
+```{r}
+# Example: Retrieve discharge data for specific sites
+discharge_data <- TADA_getNWIS(
+  sites = site_nums,
+  parameter_codes = "00060",  # Discharge in cubic feet per second
+  start_date = "2022-01-01", 
+  end_date = "2022-12-31"
+)
+```
+
+```{r}
+# Let's visualize the discharge data
+if(nrow(discharge_data) > 0) {
+  discharge_plot <- discharge_data %>%
+    dplyr::mutate(NWIS.date = as.Date(NWIS.date),
+                 NWIS.value = as.numeric(NWIS.value)) %>%
+    ggplot2::ggplot(ggplot2::aes(x = NWIS.date, y = NWIS.value, color = NWIS.site_no)) +
+    ggplot2::geom_line() +
+    ggplot2::labs(
+      title = "Daily Discharge at Selected USGS Sites",
+      x = "Date",
+      y = "Discharge (cubic feet per second)",
+      color = "Site Number"
+    ) +
+    ggplot2::theme_minimal()
+  
+  print(discharge_plot)
+}
+```

--- a/vignettes/TADAModule2.Rmd
+++ b/vignettes/TADAModule2.Rmd
@@ -368,12 +368,12 @@ continuous daily-value data from USGS water monitoring locations.
 
 ### `TADA_listNWIS()`
 
-This function retrieves available data from USGS National Water
+This function retrieves all available daily data from USGS National Water
 Information System (NWIS) based on different queries: an area of interest
-(i.e., an {sf} object), states, or specific sites.
+(i.e., an sf object), states, or specific sites.
 
-The function returns a spatial {sf} object containing site information
-and available parameters. If no data is found, it returns an empty {sf}
+The function returns a spatial sf object containing site information
+and available parameters. If no data is found, it returns an empty sf
 object with the appropriate column structure.
 
 #### Using `TADA_listNWIS()`
@@ -381,7 +381,7 @@ object with the appropriate column structure.
 Let's retrieve information about available NWIS data by a state, then visualize
 that information:
 
-```{r, eval=FALSE}
+```{r}
 # Example: Query by state 
 ri_sites <- TADA_listNWIS(states = "RI")
 
@@ -428,7 +428,7 @@ site_nums <- c("11530500", "11532500")  # Two sites in Northern California
 sites_info <- TADA_listNWIS(sites = site_nums)
 ```
 
-Lastly, can query NWIS sites by a user-supplied {sf} objects:
+Lastly, can query NWIS sites by a user-supplied sf object:
 
 ```{r}
 cherokee_sf <- sf::st_read("inst/extdata/OKTribe.shp") %>%
@@ -441,38 +441,39 @@ cherokee_nwis <- TADA_listNWIS(aoi_sf = cherokee_sf)
 
 This function retrieves and tidy-formats daily values from NWIS. It
 interfaces with the USGS National Water Information System to retrieve
-daily values (DV) water data. Like `TADA_listNWIS()`, users can
-query data based on an area of interest (i.e., an {sf} object), states,
+daily value (DV) water data. Like `TADA_listNWIS()`, users can
+query data based on an area of interest (i.e., an sf object), states,
 or specific sites.
 
 Additionally, users must specify the parameter codes they want to download
-and a date range. A list of all available parameters can be found at: https://help.waterdata.usgs.gov/parameter_cd?group_cd=%
+and a date range. A list of all available parameters can be found at: 
+https://help.waterdata.usgs.gov/parameter_cd?group_cd=%
 
 
 #### Using `TADA_getNWIS()`
 
-Let's retrieve discharge data (parameter code 00060) being collected in the {sf} 
+Let's retrieve water temperature data (parameter code 00010) being collected in the sf
 object above for January 2022:
 
 ```{r}
-# Example: Retrieve discharge data within a specified area of interest:
-discharge_data <- TADA_getNWIS(
+# Example: Retrieve water temperature data within a specified area of interest:
+temperature_data <- TADA_getNWIS(
   aoi_sf = cherokee_sf,
-  parameter_codes = "00060",  # Discharge in cubic feet per second
+  parameter_codes = "00010",  # Discharge in cubic feet per second
   start_date = "2022-01-01", 
   end_date = "2022-01-31"
 )
 
 # Let's visualize the discharge data
-discharge_data %>%
+temperature_data %>%
     dplyr::mutate(NWIS.date = as.Date(NWIS.date),
                  NWIS.value = as.numeric(NWIS.value)) %>%
     ggplot2::ggplot(ggplot2::aes(x = NWIS.date, y = NWIS.value, color = NWIS.site_no)) +
     ggplot2::geom_line() +
     ggplot2::labs(
-      title = "Daily Discharge at Selected USGS Sites",
+      title = "Daily Water Temperature at Selected USGS Sites",
       x = "Date",
-      y = "Discharge (cubic feet per second)",
+      y = "Water Temperature (Celsius)",
       color = "Site Number"
     ) +
     ggplot2::theme_minimal()

--- a/vignettes/TADAModule2.Rmd
+++ b/vignettes/TADAModule2.Rmd
@@ -415,7 +415,7 @@ leaflet::leaflet() %>%
       ri_summary$site_no,
       "<br> Parameters: ",
       ri_summary$parameters,
-      "<br> Parameter codess: ",
+      "<br> Parameter codes: ",
       ri_summary$parameter_codes
     )
   )

--- a/vignettes/TADAModule2.Rmd
+++ b/vignettes/TADAModule2.Rmd
@@ -391,9 +391,19 @@ View(sites_info)
 We can also query NWIS sites by state:
 
 ```{r, eval=FALSE}
-# Example: Query by state (showing code but not evaluating to limit runtime)
+# Example: Query by state 
 ri_sites <- TADA_listNWIS(states = "RI")
 ```
+
+We can also query NWIS sites by a user-supplied {sf} object:
+```{r}
+# Example: Query by state 
+ok_tribal_sites <- sf::st_read("inst/extdata/OKTribe.shp")
+
+ok_tribal_nwsi <- TADA_listNWIS(aoi_sf = ok_tribal_sites)
+```
+
+
 
 ### `TADA_getNWIS()`
 

--- a/vignettes/TADAModule2.Rmd
+++ b/vignettes/TADAModule2.Rmd
@@ -373,37 +373,69 @@ Information System (NWIS) based on different queries: an area of interest
 (i.e., an {sf} object), states, or specific sites.
 
 The function returns a spatial {sf} object containing site information
-and available parameters. If no data is found, it returns an empty sf
+and available parameters. If no data is found, it returns an empty {sf}
 object with the appropriate column structure.
 
 #### Using `TADA_listNWIS()`
 
-Let's retrieve information about available NWIS data for specific USGS
-monitoring sites:
-
-```{r}
-# Example: Query by specific site numbers
-site_nums <- c("11530500", "11532500")  # Two sites in Northern California
-sites_info <- TADA_listNWIS(sites = site_nums)
-View(sites_info)
-```
-
-We can also query NWIS sites by state:
+Let's retrieve information about available NWIS data by a state, then visualize
+that information:
 
 ```{r, eval=FALSE}
 # Example: Query by state 
 ri_sites <- TADA_listNWIS(states = "RI")
+
+ri_summary <- ri_sites %>%
+  dplyr::group_by(site_no) %>%
+  dplyr::summarize(parameters = paste(unique(parameter), collapse = ";  "),
+                   parameter_codes = paste(unique(parameter_code), collapse = ";  "))
+
+leaflet::leaflet() %>%
+  leaflet::addProviderTiles("Esri.WorldTopoMap",
+    group = "World topo",
+    options = leaflet::providerTileOptions(
+      updateWhenZooming = FALSE,
+      updateWhenIdle = TRUE
+    )
+  ) %>%
+  leaflet::clearShapes() %>%
+  leaflet.extras::addResetMapButton() %>%
+  leaflet::addLegend(
+    position = "bottomright",
+    colors = "black",
+    labels = "NWIS Monitoring Location(s)",
+    opacity = 1
+  ) %>%
+  leaflet::addCircleMarkers(
+    data = ri_summary,
+    color = "grey", fillColor = "black",
+    fillOpacity = 0.8, stroke = TRUE, weight = 1.5, radius = 6,
+    popup = paste0(
+      "Site Number: ",
+      ri_summary$site_no,
+      "<br> Parameters: ",
+      ri_summary$parameters,
+      "<br> Parameter codess: ",
+      ri_summary$parameter_codes
+    )
+  )
 ```
 
-We can also query NWIS sites by a user-supplied {sf} object:
+We can also query by specific USGS monitoring sites:
+
 ```{r}
-# Example: Query by state 
-ok_tribal_sites <- sf::st_read("inst/extdata/OKTribe.shp")
-
-ok_tribal_nwsi <- TADA_listNWIS(aoi_sf = ok_tribal_sites)
+site_nums <- c("11530500", "11532500")  # Two sites in Northern California
+sites_info <- TADA_listNWIS(sites = site_nums)
 ```
 
+Lastly, can query NWIS sites by a user-supplied {sf} objects:
 
+```{r}
+cherokee_sf <- sf::st_read("inst/extdata/OKTribe.shp") %>%
+  dplyr::filter(NAME == "Cherokee")
+
+cherokee_nwis <- TADA_listNWIS(aoi_sf = cherokee_sf)
+```
 
 ### `TADA_getNWIS()`
 
@@ -413,28 +445,26 @@ daily values (DV) water data. Like `TADA_listNWIS()`, users can
 query data based on an area of interest (i.e., an {sf} object), states,
 or specific sites.
 
+Additionally, users must specify the parameter codes they want to download
+and a date range. A list of all available parameters can be found at: https://help.waterdata.usgs.gov/parameter_cd?group_cd=%
 
-Additionally, users specify relevant parameter codes and a date range.
 
 #### Using `TADA_getNWIS()`
 
-Let's retrieve discharge data (parameter code 00060) for the sites we
-queried above:
+Let's retrieve discharge data (parameter code 00060) being collected in the {sf} 
+object above for January 2022:
 
 ```{r}
-# Example: Retrieve discharge data for specific sites
+# Example: Retrieve discharge data within a specified area of interest:
 discharge_data <- TADA_getNWIS(
-  sites = site_nums,
+  aoi_sf = cherokee_sf,
   parameter_codes = "00060",  # Discharge in cubic feet per second
   start_date = "2022-01-01", 
-  end_date = "2022-12-31"
+  end_date = "2022-01-31"
 )
-```
 
-```{r}
 # Let's visualize the discharge data
-if(nrow(discharge_data) > 0) {
-  discharge_plot <- discharge_data %>%
+discharge_data %>%
     dplyr::mutate(NWIS.date = as.Date(NWIS.date),
                  NWIS.value = as.numeric(NWIS.value)) %>%
     ggplot2::ggplot(ggplot2::aes(x = NWIS.date, y = NWIS.value, color = NWIS.site_no)) +
@@ -446,7 +476,4 @@ if(nrow(discharge_data) > 0) {
       color = "Site Number"
     ) +
     ggplot2::theme_minimal()
-  
-  print(discharge_plot)
-}
 ```


### PR DESCRIPTION
Hey Matt!

Here's a PR containing two new functions:

`TADA_listNWIS()` returns a spatial summary of available USGS NWIS daily data based on site numbers, state codes, or a spatial area.

`TADA_getNWIS()` Retrieves and tidies USGS NWIS daily values for selected sites, states, or areas based on parameter codes and date range.

I also added some {testthat} function tests to make sure they work as expected, and I added a brief demo of their use in the Module2 vignette.

These two functions fulfill TADA's want of accessing the USGS's continuous data. It is quite simple as-is (it only pulls continuous daily data, for example), but I'm hopeful it will act as a launching off point for other functionality in the future if they choose. 

Because I still have other updates to the package, I did not build these into the package yet. (So, when testing, you will need to source the ContinuousDataFunctions.R file on top of load_all(), I think!)

If you could please review the code and also test that the code in the examples for each function, the module, and the testthat workflows run for you? 

After this PR, I will submit another one containing updates to currently-existing geospatial functions. 

Thanks!
Katie
